### PR TITLE
feat: Google認証後のトークンとユーザー情報の保存方法を改善 #1

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -18,6 +18,7 @@
 	"license": "ISC",
 	"packageManager": "pnpm@10.11.0",
 	"dependencies": {
+		"@fastify/cookie": "^11.0.2",
 		"@fastify/cors": "^11.0.1",
 		"@fastify/jwt": "^9.1.0",
 		"@fastify/static": "^8.2.0",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import fastifyCookie from "@fastify/cookie";
 import fastifyCors from "@fastify/cors";
 import fastifyStatic from "@fastify/static";
 import fastify from "fastify";
@@ -23,6 +24,9 @@ server.register(fastifyCors, {
 	origin: process.env.FRONTEND_URL || "http://localhost:8080",
 	credentials: true,
 });
+
+// Register Cookie plugin
+server.register(fastifyCookie);
 
 // Register JWT plugin
 server.register(jwtPlugin);

--- a/packages/backend/src/plugins/jwt.ts
+++ b/packages/backend/src/plugins/jwt.ts
@@ -27,7 +27,15 @@ async function jwtPlugin(
 		"authenticate",
 		async (request: FastifyRequest, reply: FastifyReply) => {
 			try {
-				await request.jwtVerify();
+				// First try to get token from cookie
+				const token = request.cookies.authToken;
+				if (token) {
+					const decoded = await fastify.jwt.verify(token);
+					request.user = decoded;
+				} else {
+					// Fallback to Authorization header for backwards compatibility
+					await request.jwtVerify();
+				}
 			} catch (_err) {
 				reply.code(401).send({ error: "Unauthorized" });
 			}

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -51,8 +51,16 @@ export default async function authRoutes(fastify: FastifyInstance) {
 			// Generate JWT token
 			const token = fastify.jwt.sign({ user } as JWTPayload);
 
+			// Set httpOnly cookie
+			reply.setCookie("authToken", token, {
+				httpOnly: true,
+				secure: process.env.NODE_ENV === "production",
+				sameSite: "strict",
+				path: "/",
+				maxAge: 60 * 60 * 24 * 7, // 7 days
+			});
+
 			return reply.send({
-				token,
 				user,
 			});
 		} catch (error) {
@@ -74,8 +82,10 @@ export default async function authRoutes(fastify: FastifyInstance) {
 
 	// Sign out endpoint
 	fastify.post("/auth/sign-out", async (_request, reply) => {
-		// Note: With JWT, actual sign-out happens on the client side
-		// by removing the token from storage
+		// Clear the httpOnly cookie
+		reply.clearCookie("authToken", {
+			path: "/",
+		});
 		return reply.send({ message: "Sign out successfully" });
 	});
 }

--- a/packages/frontend/src/contexts/Auth.tsx
+++ b/packages/frontend/src/contexts/Auth.tsx
@@ -24,19 +24,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 	useEffect(() => {
 		// Check if user is already authenticated on app load
 		const verifyAuth = async () => {
-			const token = localStorage.getItem("authToken");
-
-			if (!token) {
-				setIsVerifying(false);
-				return;
-			}
-
 			try {
-				// Verify token with backend
+				// Verify token with backend (cookie will be sent automatically)
 				const response = await fetch("/auth/verify", {
-					headers: {
-						Authorization: `Bearer ${token}`,
-					},
+					credentials: "include",
 				});
 
 				if (response.ok) {
@@ -45,13 +36,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 					if (jwtPayload.user) {
 						setUser(jwtPayload.user);
 					}
-				} else {
-					// Token is invalid or expired
-					localStorage.removeItem("authToken");
 				}
 			} catch (error) {
 				console.error("Auth verification failed:", error);
-				localStorage.removeItem("authToken");
 			} finally {
 				setIsVerifying(false);
 			}
@@ -65,25 +52,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 	};
 
 	const signOut = async () => {
-		const token = localStorage.getItem("authToken");
-
 		// Clear local state immediately for better UX
 		setUser(null);
-		localStorage.removeItem("authToken");
 
-		// Call server sign out endpoint if token exists
-		if (token) {
-			try {
-				await fetch("/auth/sign-out", {
-					method: "POST",
-					headers: {
-						Authorization: `Bearer ${token}`,
-					},
-				});
-			} catch (error) {
-				// Log error but don't throw - user is already signed out locally
-				console.error("Server sign out error:", error);
-			}
+		// Call server sign out endpoint
+		try {
+			await fetch("/auth/sign-out", {
+				method: "POST",
+				credentials: "include",
+			});
+		} catch (error) {
+			// Log error but don't throw - user is already signed out locally
+			console.error("Server sign out error:", error);
 		}
 	};
 

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -23,6 +23,7 @@ function Home() {
 					headers: {
 						"Content-Type": "application/json",
 					},
+					credentials: "include",
 					body: JSON.stringify({
 						idToken: credentialResponse.credential,
 					}),
@@ -36,10 +37,7 @@ function Home() {
 					throw new Error("Authentication failed");
 				}
 
-				const { user, token } = await response.json();
-
-				// Store JWT token in localStorage
-				localStorage.setItem("authToken", token);
+				const { user } = await response.json();
 
 				// Update auth context
 				signIn(user);
@@ -58,19 +56,8 @@ function Home() {
 
 	const handleSignOut = async () => {
 		try {
-			// Call sign out endpoint
-			await fetch("/api/auth/sign-out", {
-				method: "POST",
-				headers: {
-					Authorization: `Bearer ${localStorage.getItem("authToken")}`,
-				},
-			});
-
-			// Clear local storage
-			localStorage.removeItem("authToken");
-
-			// Update auth context
-			signOut();
+			// Update auth context (this will handle server-side sign out)
+			await signOut();
 		} catch (error) {
 			console.error("Sign out error:", error);
 		}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
 
   packages/backend:
     dependencies:
+      '@fastify/cookie':
+        specifier: ^11.0.2
+        version: 11.0.2
       '@fastify/cors':
         specifier: ^11.0.1
         version: 11.0.1
@@ -433,6 +436,9 @@ packages:
 
   '@fastify/ajv-compiler@4.0.2':
     resolution: {integrity: sha512-Rkiu/8wIjpsf46Rr+Fitd3HRP+VsxUFDDeag0hs9L0ksfnwx2g7SPQQTFL0E8Qv+rfXzQOxBJnjUB9ITUDjfWQ==}
+
+  '@fastify/cookie@11.0.2':
+    resolution: {integrity: sha512-GWdwdGlgJxyvNv+QcKiGNevSspMQXncjMZ1J8IvuDQk0jvkzgWWZFNC2En3s+nHndZBGV8IbLwOI/sxCZw/mzA==}
 
   '@fastify/cors@11.0.1':
     resolution: {integrity: sha512-dmZaE7M1f4SM8ZZuk5RhSsDJ+ezTgI7v3HHRj8Ow9CneczsPLZV6+2j2uwdaSLn8zhTv6QV0F4ZRcqdalGx1pQ==}
@@ -2388,6 +2394,11 @@ snapshots:
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
       fast-uri: 3.0.6
+
+  '@fastify/cookie@11.0.2':
+    dependencies:
+      cookie: 1.0.2
+      fastify-plugin: 5.0.1
 
   '@fastify/cors@11.0.1':
     dependencies:


### PR DESCRIPTION
## 概要
Issue #1 の対応として、Google認証後のトークンとユーザー情報の保存方法をセキュリティ強化のため改善しました。

## 変更内容
### バックエンド
- JWTトークンをhttpOnlyのクッキーに保存するように変更
- `@fastify/cookie`パッケージを導入
- 認証ミドルウェアがクッキーからもトークンを読み取れるように更新
- サインアウト時にクッキーをクリアする処理を追加

### フロントエンド
- ローカルストレージへのトークン保存を完全に削除
- APIリクエストに`credentials: 'include'`を追加してクッキーを送信
- ユーザー情報はReact Stateのみで管理

## テスト項目
- [ ] Google認証でのサインインが正常に動作すること
- [ ] 認証後、ページをリロードしてもログイン状態が維持されること
- [ ] サインアウトが正常に動作すること
- [ ] ローカルストレージにトークンが保存されていないこと

## 関連Issue
Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)