### PR TITLE
feat: add authentication protection to dashboard route

### DIFF
--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -13,8 +13,6 @@ export default async function authRoutes(fastify: FastifyInstance) {
 		fastify.log.error(request.body);
 		const { idToken } = request.body as { idToken: string };
 
-		fastify.log.error(idToken);
-
 		if (!idToken) {
 			return reply.code(400).send({ error: "ID token is required" });
 		}

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -13,6 +13,8 @@ export default async function authRoutes(fastify: FastifyInstance) {
 		fastify.log.error(request.body);
 		const { idToken } = request.body as { idToken: string };
 
+		fastify.log.error(idToken);
+
 		if (!idToken) {
 			return reply.code(400).send({ error: "ID token is required" });
 		}

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { GoogleOAuthProvider } from "@react-oauth/google";
 import { Route, Routes } from "react-router-dom";
+import ProtectedRoute from "./components/ProtectedRoute";
 import { AuthProvider } from "./contexts/Auth";
 import Dashboard from "./pages/Dashboard";
 import Home from "./pages/Home";
@@ -23,7 +24,14 @@ function App() {
 			<AuthProvider>
 				<Routes>
 					<Route path="/" element={<Home />} />
-					<Route path="/dashboard" element={<Dashboard />} />
+					<Route
+						path="/dashboard"
+						element={
+							<ProtectedRoute>
+								<Dashboard />
+							</ProtectedRoute>
+						}
+					/>
 				</Routes>
 			</AuthProvider>
 		</GoogleOAuthProvider>

--- a/packages/frontend/src/components/ProtectedRoute.tsx
+++ b/packages/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,22 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../contexts/Auth";
+
+interface ProtectedRouteProps {
+	children: React.ReactNode;
+}
+
+function ProtectedRoute({ children }: ProtectedRouteProps) {
+	const { user, isVerifying } = useAuth();
+
+	if (isVerifying) {
+		return <div>Loading...</div>;
+	}
+
+	if (!user) {
+		return <Navigate to="/" replace />;
+	}
+
+	return <>{children}</>;
+}
+
+export default ProtectedRoute;


### PR DESCRIPTION
## Summary
- Created ProtectedRoute component to protect authenticated routes
- Applied ProtectedRoute to /dashboard route
- Unauthenticated users are now redirected to home page

## Why this approach?
1. **Component-based solution**: Created a reusable ProtectedRoute component that can be used for any route requiring authentication
2. **Declarative routing**: Uses React Router's component composition pattern, making it clear which routes are protected
3. **Loading state handling**: Shows "Loading..." while authentication is being verified to prevent flash of content
4. **Navigate component**: Uses React Router's Navigate component with replace prop to properly handle browser history

## Test plan
- [x] Access `/dashboard` without authentication → redirects to `/`
- [x] Sign in with Google → can access `/dashboard`
- [x] Direct URL access to `/dashboard` when authenticated → shows dashboard
- [ ] Sign out from dashboard → redirects to home page
- [x] Browser back button after redirect works correctly

Fixes #3

🤖 Generated with [Claude Code](https://claude.ai/code)